### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/maq-utils-chartutils/package.json
+++ b/maq-utils-chartutils/package.json
@@ -7,7 +7,6 @@
     "ChartUtils"
   ],
   "repository": {
-    "type": "git",
     "url": "https://github.com/MAQ-Software-Solutions/PowerBI-visuals-NPM.git",
     "directory": "maq-utils-chartutils"
   },

--- a/maq-utils-chartutils/package.json
+++ b/maq-utils-chartutils/package.json
@@ -6,6 +6,11 @@
   "keywords": [
     "ChartUtils"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MAQ-Software-Solutions/PowerBI-visuals-NPM.git",
+    "directory": "maq-utils-chartutils"
+  },
   "author": "MAQ Software",
   "license": "MIT",
   "bugs": {

--- a/maq-utils-chartutils/package.json
+++ b/maq-utils-chartutils/package.json
@@ -7,6 +7,7 @@
     "ChartUtils"
   ],
   "repository": {
+    "type": "git",
     "url": "https://github.com/MAQ-Software-Solutions/PowerBI-visuals-NPM.git",
     "directory": "maq-utils-chartutils"
   },

--- a/maq-visuals-legend-chartutils/package.json
+++ b/maq-visuals-legend-chartutils/package.json
@@ -10,6 +10,11 @@
   "keywords": [
     "ChartUtils"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MAQ-Software-Solutions/PowerBI-visuals-NPM.git",
+    "directory": "maq-visuals-legend-chartutils"
+  },
   "author": "MAQ Software",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources. 

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR. 

Published NPM packages with repository information:
• maq-utils-chartutils
• maq-visuals-legend-chartutils